### PR TITLE
Update compiler source version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
  <properties>
    <maven.compiler.plugin>3.10.1</maven.compiler.plugin>
    <maven.war.plugin>3.3.2</maven.war.plugin>
-   <maven.compiler.source>6</maven.compiler.source>
+   <maven.compiler.source>9</maven.compiler.source>
    <maven.compiler.target>1.6</maven.compiler.target>
  </properties>
 


### PR DESCRIPTION
Build on Fedora 38 fails complaining that the version must be at least 7. I bumped the version to 9 which works both on Fedora 38 and 37. (7 works fine too if we want to go with the bare minimum)